### PR TITLE
Replaced dependency on GCS with local storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,3 @@ TINYBIRD_API_URL=https://api.tinybird.co
 TINYBIRD_ID=745d3247-e887-4873-84f7-7414ec758b83
 TINYBIRD_TRACKER_TOKEN=p.eyJxxxxx
 TINYBIRD_STATS_TOKEN=p.eyJxxxxx
-
-# Activity Pub Configuration
-GOOGLE_CLOUD_PROJECT=project-id
-ACTIVITYPUB_GCP_BUCKET=bucket-name

--- a/compose.yml
+++ b/compose.yml
@@ -90,10 +90,9 @@ services:
     image: ghcr.io/tryghost/activitypub:edge
     restart: always
     volumes:
-      - ./gcscreds.json:/home/gcs/gcscreds.json
+      - ghost_content:/opt/activitypub/content
     expose:
       - "8080"
-      - "9229"
     environment:
       NODE_ENV: production
       PORT: 8080
@@ -103,9 +102,8 @@ services:
       MYSQL_DATABASE: activitypub
       ALLOW_PRIVATE_ADDRESS: true
       USE_MQ: false
-      GCP_BUCKET_NAME: ${ACTIVITYPUB_GCP_BUCKET:?ACTIVITYPUB_GCP_BUCKET environment variable is required}
-      GOOGLE_CLOUD_PROJECT: ${GOOGLE_CLOUD_PROJECT:?GOOGLE_CLOUD_PROJECT envirobment variable is required}
-      GOOGLE_APPLICATION_CREDENTIALS: /home/gcs/gcscreds.json
+      LOCAL_STORAGE_PATH: /opt/activitypub/content/images/activitypub
+      LOCAL_STORAGE_HOSTING_URL: https://${DOMAIN}/content/images/activitypub
     depends_on:
       - db
     profiles: [activitypub]


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2009

ActivityPub now supports configuring a local storage adapter, we defer to the ghost service for actually serving the images, so we write to a shared volume and point our URLs at the Ghost content directory.