### PR TITLE
Ghost/AP: Added dependency pinning

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -49,6 +49,9 @@ services:
       tinybird-deploy:
         condition: service_completed_successfully
         required: false
+      activitypub:
+        condition: service_started
+        required: false
     networks:
       - ghost_network
 
@@ -89,10 +92,10 @@ services:
   activitypub:
     image: ghcr.io/tryghost/activitypub:edge
     restart: always
-    volumes:
-      - ghost_content:/opt/activitypub/content
     expose:
       - "8080"
+    volumes:
+      - ghost_content:/opt/activitypub/content
     environment:
       NODE_ENV: production
       PORT: 8080


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2411

- This doesn't completely solve the 'Ghost mustn't start will AP does' problem _but_ does save it on cold boots or when the whole stack isn't running
- If Ghost is already running it unfortunately wont restart but we can work around that with docs