### PR TITLE
TB: Remove requirement for UUID setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,21 +1,33 @@
+# Use the below flags to enable the Analytics or ActivityPub containers as well
+# Note: You must set ENABLE_DEVELOPER_EXPERIMENTS to `true` when enabling either profile below
 # COMPOSE_PROFILES=analytics,activitypub
 
 # Which Ghost version to run
 GHOST_VERSION=5-alpine
 
+# Public domain Ghost is going to run on
 DOMAIN=example.com
 
+# Database settings
+DATABASE_ROOT_PASSWORD=reallysecurerootpassword
+DATABASE_USER=optionalusername
+DATABASE_PASSWORD=ghostpassword
+
+# Developer Experiences must be enabled for
+# both Traffic Analytics and ActivityPub
+ENABLE_DEVELOPER_EXPERIMENTS=false
+
+# Developer Experiments must be enabled above
+ENABLE_ACTIVITYPUB=false
+
+# Tinybird configuration
+TINYBIRD_API_URL=https://api.tinybird.co
+TINYBIRD_TRACKER_TOKEN=p.eyJxxxxx
+TINYBIRD_STATS_TOKEN=p.eyJxxxxx
+
+# Data locations
 # Location to store uploaded data
 UPLOAD_LOCATION=./data/ghost
 
 # Location for database data
 MYSQL_DATA_LOCATION=./data/mysql
-
-DATABASE_ROOT_PASSWORD=reallysecurerootpassword
-DATABASE_USER=optionalusername
-DATABASE_PASSWORD=ghostpassword
-
-# Tinybird configuration for analytics
-TINYBIRD_API_URL=https://api.tinybird.co
-TINYBIRD_TRACKER_TOKEN=p.eyJxxxxx
-TINYBIRD_STATS_TOKEN=p.eyJxxxxx

--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,5 @@ DATABASE_PASSWORD=ghostpassword
 
 # Tinybird configuration for analytics
 TINYBIRD_API_URL=https://api.tinybird.co
-TINYBIRD_ID=745d3247-e887-4873-84f7-7414ec758b83
 TINYBIRD_TRACKER_TOKEN=p.eyJxxxxx
 TINYBIRD_STATS_TOKEN=p.eyJxxxxx

--- a/TINYBIRD.md
+++ b/TINYBIRD.md
@@ -11,5 +11,6 @@ Steps:
 1. Using the UI link from the previous step, open your workspace and click on *Tokens* in the left hand menu
 1. Copy your Tinybird `stats_page` token and add it to your `.env` file as `TINYBIRD_STATS_TOKEN`
 1. Copy your Tinybird `tracker` token and add it to your `.env` file as `TINYBIRD_TRACKER_TOKEN`
-1. Run `docker compose --profile=analytics up -d` to start all services in the background. You can also set `COMPOSE_PROFILES=analytics` in your `.env` file to automatically include the `analytics` profile when running `docker compose` commands.
+1. Run `docker compose --profile=analytics up -d` to start all services in the background
+1. Set `COMPOSE_PROFILES=analytics` in your `.env` file to automatically include the `analytics` profile when running `docker compose` commands
 1. At this point, everything should be working. You can test it's working by visiting your site's homepage, then checking the Stats page in Ghost Admin — you should see a view recorded.

--- a/compose.yml
+++ b/compose.yml
@@ -37,11 +37,9 @@ services:
       labs__trafficAnalytics: true
       labs__ActivityPub: true
       tinybird__tracker__endpoint: https://${DOMAIN:?DOMAIN environment variable is required}/.ghost/analytics/tb/web_analytics
-      tinybird__tracker__id: ${TINYBIRD_ID:-}
       tinybird__tracker__datasource: analytics_events
       tinybird__tracker__token: ${TINYBIRD_TRACKER_TOKEN:-}
       tinybird__stats__endpoint: ${TINYBIRD_API_URL:-https://api.tinybird.co}
-      tinybird__stats__id: ${TINYBIRD_ID:-}
       tinybird__stats__token: ${TINYBIRD_STATS_TOKEN:-}
     volumes:
       - ${UPLOAD_LOCATION:-./data/ghost}:/var/lib/ghost/content

--- a/compose.yml
+++ b/compose.yml
@@ -33,9 +33,8 @@ services:
       database__connection__user: ${DATABASE_USER:-ghost}
       database__connection__password: ${DATABASE_PASSWORD:?DATABASE_PASSWORD environment variable is required}
       database__connection__database: ghost
-      enableDeveloperExperiments: true
-      labs__trafficAnalytics: true
-      labs__ActivityPub: true
+      enableDeveloperExperiments: ${ENABLE_DEVELOPER_EXPERIMENTS:-false}
+      labs__ActivityPub: ${ENABLE_ACTIVITYPUB:-false}
       tinybird__tracker__endpoint: https://${DOMAIN:?DOMAIN environment variable is required}/.ghost/analytics/tb/web_analytics
       tinybird__tracker__datasource: analytics_events
       tinybird__tracker__token: ${TINYBIRD_TRACKER_TOKEN:-}


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/ENG-2442/
ref https://github.com/TryGhost/Ghost/commit/e97d6c027ca82c4595dc5700e651b9df382934ae

- Ghost used to require this to set/manage a UUID in TB/clickhouse but we now use Ghost's generated one directly, instead of requiring it here
- Cleaning this up because otherwise if they don't match the UI and the tracking events don't go to the same bucket