### PR TITLE
Ghost: Added some very basic mail setup placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,15 @@ UPLOAD_LOCATION=./data/ghost
 
 # Location for database data
 MYSQL_DATA_LOCATION=./data/mysql
+
+# Ghost configuration (https://ghost.org/docs/config/)
+
+# Email (https://ghost.org/docs/config/#mail)
+# Email is critical for account creation (Staff invites), password resets and othere pieces of functionality
+# Even if you aren't using Ghost's newsletters features it should be set up
+# mail__transport=SMTP
+# mail__options__host=smtp.example.com
+# mail__options__port=465
+# mail__options__secure=true
+# mail__options__auth__user=postmaster@example.com
+# mail__options__auth__pass=1234567890

--- a/.env.example
+++ b/.env.example
@@ -39,9 +39,9 @@ MYSQL_DATA_LOCATION=./data/mysql
 
 # Ghost configuration (https://ghost.org/docs/config/)
 
-# Email (https://ghost.org/docs/config/#mail)
-# Email is critical for account creation (Staff invites), password resets and othere pieces of functionality
-# Even if you aren't using Ghost's newsletters features it should be set up
+# SMTP Email (https://ghost.org/docs/config/#mail)
+# Transactional email is required for logins, account creation (staff invites), password resets and other features
+# This is not related to bulk mail / newsletter sending
 # mail__transport=SMTP
 # mail__options__host=smtp.example.com
 # mail__options__port=465


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2435

- Mail must be setup to have a proper functioning Ghost install
- Bulk mail doesn't require env variables but standard SMTP mail does
- We'll update the docs but prompting users in the example env file is a starting point