### PR TITLE
Updated Tinybird config and instructions for using JWTs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,12 +24,13 @@ ENABLE_DEVELOPER_EXPERIMENTS=false
 
 # Developer Experiments must be enabled above
 ENABLE_ACTIVITYPUB=false
-ENABLE_ANALYTICS=false
+ENABLE_TRAFFIC_ANALYTICS=false
 
 # Tinybird configuration
 TINYBIRD_API_URL=https://api.tinybird.co
 TINYBIRD_TRACKER_TOKEN=p.eyJxxxxx
 TINYBIRD_ADMIN_TOKEN=p.eyJxxxxx
+TINYBIRD_WORKSPACE_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
 # Data locations
 # Location to store uploaded data

--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,7 @@ ENABLE_DEVELOPER_EXPERIMENTS=false
 
 # Developer Experiments must be enabled above
 ENABLE_ACTIVITYPUB=false
+ENABLE_ANALYTICS=false
 
 # Tinybird configuration
 TINYBIRD_API_URL=https://api.tinybird.co

--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@ ENABLE_ACTIVITYPUB=false
 # Tinybird configuration
 TINYBIRD_API_URL=https://api.tinybird.co
 TINYBIRD_TRACKER_TOKEN=p.eyJxxxxx
-TINYBIRD_STATS_TOKEN=p.eyJxxxxx
+TINYBIRD_ADMIN_TOKEN=p.eyJxxxxx
 
 # Data locations
 # Location to store uploaded data

--- a/TINYBIRD.md
+++ b/TINYBIRD.md
@@ -7,9 +7,11 @@ Steps:
 1. Run `docker compose run --rm tinybird-login` to login to your Tinybird account
 1. Run `docker compose --profile=analytics up tinybird-sync`. This will copy the Tinybird files from the Ghost container into a shared volume. The service should log "Tinybird files synced into shared volume.", then exit.
 1. Run `docker compose --profile=analytics up tinybird-deploy` and wait for the service to exit successfully. This will create your Tinybird datasources, pipes and API endpoints. It may take a minute or two to complete the first time. You should see "Deployment #1 is live!" in your terminal before the service exits.
-1. Find your workspace's events API endpoint: `docker compose run --rm tinybird-login tb --cloud info`, copy the value of "api", and add it to your `.env` file as `TINYBIRD_API_URL`. You can also find this value in your Tinybird Workspace's UI. 
+1. Find your workspace's ID and events API endpoint: `docker compose run --rm tinybird-login tb --cloud info`
+    - Copy the value of "api", and add it to your `.env` file as `TINYBIRD_API_URL`. You can also find this value in your Tinybird Workspace's UI. 
+    - Copy the value of "workspace_id", and add it to your `.env` file as `TINYBIRD_WORKSPACE_ID`
 1. Using the UI link from the previous step, open your workspace and click on *Tokens* in the left hand menu
-1. Copy your Tinybird `stats_page` token and add it to your `.env` file as `TINYBIRD_STATS_TOKEN`
+1. Copy your Tinybird "Workspace admin token" and add it to your `.env` file as `TINYBIRD_ADMIN_TOKEN`
 1. Copy your Tinybird `tracker` token and add it to your `.env` file as `TINYBIRD_TRACKER_TOKEN`
 1. Run `docker compose --profile=analytics up -d` to start all services in the background
 1. Set `COMPOSE_PROFILES=analytics` in your `.env` file to automatically include the `analytics` profile when running `docker compose` commands

--- a/TINYBIRD.md
+++ b/TINYBIRD.md
@@ -1,18 +1,17 @@
 # Tinybird Configuration
 
-Note: Currently Traffic Analytics features are behind a feature flag. For now, you'll need to enable developer experiments by setting `ENABLE_DEV_EXPERIMENTS=true` in your `.env` file, and enable the Traffic Analytics feature flag under Settings > Labs > Private Features.
+Note: Currently Traffic Analytics features are behind a feature flag. For now, you'll need to enable it by following the steps below:
 
-Steps:
 1. Create a Tinybird account and a Tinybird workspace at [tinybird.co](https://auth.tinybird.co/login). You can select any cloud/region you choose.
-1. Run `docker compose run --rm tinybird-login` to login to your Tinybird account
+1. Run `docker compose run --rm tinybird-login` to login to your Tinybird account following the steps given
 1. Run `docker compose --profile=analytics up tinybird-sync`. This will copy the Tinybird files from the Ghost container into a shared volume. The service should log "Tinybird files synced into shared volume.", then exit.
 1. Run `docker compose --profile=analytics up tinybird-deploy` and wait for the service to exit successfully. This will create your Tinybird datasources, pipes and API endpoints. It may take a minute or two to complete the first time. You should see "Deployment #1 is live!" in your terminal before the service exits.
 1. Find your workspace's ID and events API endpoint: `docker compose run --rm tinybird-login tb --cloud info`
-    - Copy the value of "api", and add it to your `.env` file as `TINYBIRD_API_URL`. You can also find this value in your Tinybird Workspace's UI. 
-    - Copy the value of "workspace_id", and add it to your `.env` file as `TINYBIRD_WORKSPACE_ID`
+    1. Copy the value of "api", and add it to your `.env` file as `TINYBIRD_API_URL`. You can also find this value in your Tinybird Workspace's UI. 
+    1. Copy the value of "workspace_id", and add it to your `.env` file as `TINYBIRD_WORKSPACE_ID`
 1. Using the UI link from the previous step, open your workspace and click on *Tokens* in the left hand menu
 1. Copy your Tinybird "Workspace admin token" and add it to your `.env` file as `TINYBIRD_ADMIN_TOKEN`
 1. Copy your Tinybird `tracker` token and add it to your `.env` file as `TINYBIRD_TRACKER_TOKEN`
 1. Run `docker compose --profile=analytics up -d` to start all services in the background
-1. Set `COMPOSE_PROFILES=analytics` in your `.env` file to automatically include the `analytics` profile when running `docker compose` commands
+1. Add `analytics` to `COMPOSE_PROFILES=` in the top of your `.env` file to automatically include the `analytics` profile when running `docker compose` commands
 1. At this point, everything should be working. You can test it's working by visiting your site's homepage, then checking the Stats page in Ghost Admin — you should see a view recorded.

--- a/compose.yml
+++ b/compose.yml
@@ -37,6 +37,7 @@ services:
       database__connection__database: ghost
       enableDeveloperExperiments: ${ENABLE_DEVELOPER_EXPERIMENTS:-false}
       labs__ActivityPub: ${ENABLE_ACTIVITYPUB:-false}
+      labs__trafficAnalytics: ${ENABLE_TRAFFIC_ANALYTICS:-false}
       tinybird__tracker__endpoint: https://${DOMAIN:?DOMAIN environment variable is required}/.ghost/analytics/api/v1/page_hit
       tinybird__adminToken: ${TINYBIRD_ADMIN_TOKEN:-}
       tinybird__workspaceId: ${TINYBIRD_WORKSPACE_ID:-}

--- a/compose.yml
+++ b/compose.yml
@@ -38,9 +38,10 @@ services:
       enableDeveloperExperiments: ${ENABLE_DEVELOPER_EXPERIMENTS:-false}
       labs__ActivityPub: ${ENABLE_ACTIVITYPUB:-false}
       tinybird__tracker__endpoint: https://${DOMAIN:?DOMAIN environment variable is required}/.ghost/analytics/api/v1/page_hit
+      tinybird__adminToken: ${TINYBIRD_ADMIN_TOKEN:-}
+      tinybird__workspaceId: ${TINYBIRD_WORKSPACE_ID:-}
       tinybird__tracker__datasource: analytics_events
       tinybird__stats__endpoint: ${TINYBIRD_API_URL:-https://api.tinybird.co}
-      tinybird__stats__token: ${TINYBIRD_STATS_TOKEN:-}
     volumes:
       - ${UPLOAD_LOCATION:-./data/ghost}:/var/lib/ghost/content
     depends_on:


### PR DESCRIPTION
We've switched from using the static `stats_token` to generating dynamic JWTs for querying Tinybird's endpoints. The workspace ID and admin token are required to sign the JWTs, so we need to add those to the configuration. The stats token is no longer used, so this also removes it. 

It also adds the labs flag via config to allow enabling analytics in the `.env` file, instead of requiring the user to enable it in the UI. 