### PR TITLE
Fixed `tinybird-login` service hanging in detached mode when not logged in

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -135,7 +135,7 @@ services:
     profiles: [analytics]
     networks:
       - ghost_network
-    tty: true
+    tty: false
     restart: no
 
   tinybird-sync:

--- a/tinybird/handleLogin.sh
+++ b/tinybird/handleLogin.sh
@@ -19,5 +19,13 @@ then
     exit 0
 fi
 
+# Check if running in interactive environment
+## If not logged in and running in non-interactive mode (i.e. `docker compose up -d`), the tinybird-login service will hang indefinitely
+if [[ ! -t 0 ]] || [[ ! -t 1 ]]; then
+        echo "Not logged in to Tinybird and running in non-interactive mode."
+        echo "Please run 'docker compose run --rm tinybird-login' to login interactively."
+        exit 1
+fi
+
 # Login to Tinybird
 tb login --method code


### PR DESCRIPTION
As I was testing the Tinybird migration process, I (intentionally) un-authenticated myself with Tinybird by deleting the `.tinyb` file from the `tinybird_home` volume. This shouldn't happen under normal circumstances, but it's possible if i.e. the volume gets deleted. 

When not logged in to Tinybird, if you just run `docker compose up -d`, the `tinybird-login` service will hang indefinitely, as it waits for user input to select a region. Since it's running in detached mode, it just keeps going and doesn't seem to ever timeout (it might eventually, but we should provide quicker feedback in this case regardless).

This PR makes two small tweaks, so that the `tinybird-login` service will exit with code 1 more or less immediately when trying to run `docker compose up -d` if not logged in to Tinybird already:
- Adds a check to the `handleLogin.sh` script, which will echo an error message and exit with code 1 if running in non-interactive mode (i.e. `docker compose up -d`), but passes if run with `docker compose run --rm tinybird-login`
- Changes `tty` to `false` for the docker compose file. This apparently isn't needed to run interactively with `docker compose run --rm tinybird-login`, but having it set to `true` would trick the `handleLogin.sh` script into thinking it's running interactively, even when it's not.


Testing:
I tested this by:
1. Deleting the `.tinyb` file from the `tinybird_home` volume — I used `docker compose run --rm tinybird-login sh` and then manually deleted the file, but removing the volume directly should also do the trick.
2. Running `docker compose up -d` — the `tinybird-login` service should exit with non-zero code, and its dependent services should not run.
3. Running `docker compose run --rm tinybird-login` to login — everything should work just as before
4. Running `docker compose up -d` again, this time it should all succeed. 