### PR TITLE
Removed developer experiments configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,4 @@
 # Use the below flags to enable the Analytics or ActivityPub containers as well
-# Note: You must set ENABLE_DEVELOPER_EXPERIMENTS to `true` when enabling either profile below
 # COMPOSE_PROFILES=analytics,activitypub
 
 # Which Ghost version to run
@@ -22,10 +21,6 @@ DATABASE_PASSWORD=ghostpassword
 # You should only need to edit this if you want to host
 # multiple sites on the same server
 # GHOST_PORT=2368
-
-# Developer Experiences must be enabled for
-# both Traffic Analytics and ActivityPub
-ENABLE_DEVELOPER_EXPERIMENTS=false
 
 # ActivityPub
 # If you'd prefer to self-host ActivityPub yourself uncomment the below line

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,10 +80,9 @@ The repository includes comprehensive migration tools:
 
 1. Clone repository and copy `.env.example` to `.env`
 2. Configure required environment variables (domain, passwords)
-3. Enable developer experiments if using analytics/ActivityPub
-4. Run `docker compose up -d` to start services
-5. Access Ghost at `https://DOMAIN` (Caddy handles SSL automatically)
-6. Monitor logs with `docker compose logs -f ghost`
+3. Run `docker compose up -d` to start services
+4. Access Ghost at `https://DOMAIN` (Caddy handles SSL automatically)
+5. Monitor logs with `docker compose logs -f ghost`
 
 For analytics setup, see `TINYBIRD.md` for detailed instructions.
 

--- a/compose.yml
+++ b/compose.yml
@@ -37,7 +37,6 @@ services:
       database__connection__user: ${DATABASE_USER:-ghost}
       database__connection__password: ${DATABASE_PASSWORD:?DATABASE_PASSWORD environment variable is required}
       database__connection__database: ghost
-      enableDeveloperExperiments: ${ENABLE_DEVELOPER_EXPERIMENTS:-false}
       tinybird__tracker__endpoint: https://${DOMAIN:?DOMAIN environment variable is required}/.ghost/analytics/api/v1/page_hit
       tinybird__adminToken: ${TINYBIRD_ADMIN_TOKEN:-}
       tinybird__workspaceId: ${TINYBIRD_WORKSPACE_ID:-}


### PR DESCRIPTION
Developer experiments used to be required in v5 but as we've switched to v6 they are no longer required to enable activitypub and traffic analytics.