### PR TITLE
Updated missed v6 docker image update

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -144,7 +144,7 @@ services:
 
   tinybird-sync:
     # Do not alter this without updating the Ghost container as well
-    image: ghost:${GHOST_VERSION:-5-alpine}
+    image: ghost:${GHOST_VERSION:-6.0.0-rc.0-alpine}
     command: >
       sh -c "
         if [ -d /var/lib/ghost/current/core/server/data/tinybird ]; then


### PR DESCRIPTION
This will only have an effect when the version isn't set in the .env file and we have it in the .env.example but did still need updating as the fallback.