### PR TITLE
Removed `GHOST_VERSION` from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,6 @@
 # Use the below flags to enable the Analytics or ActivityPub containers as well
 # COMPOSE_PROFILES=analytics,activitypub
 
-# Which Ghost version to run
-GHOST_VERSION=6.0.0-rc.0-alpine
-
 # Public domain Ghost is going to run on
 DOMAIN=example.com
 


### PR DESCRIPTION
Setting this value in the `.env.example` will effectively pin the Ghost version forever, so future upgrades using `git pull && docker compose pull && docker compose up -d` will stay on the original version, unless the user manually edits their `.env` file.