### PR TITLE
Commented out the `DATABASE_USER` in `.env.example`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ DOMAIN=example.com
 
 # Database settings
 DATABASE_ROOT_PASSWORD=reallysecurerootpassword
-DATABASE_USER=optionalusername
+# DATABASE_USER=optionalusername
 DATABASE_PASSWORD=ghostpassword
 
 # Port Ghost should listen on


### PR DESCRIPTION
Leaving this value un-commented makes the default database user `optionalusername` instead of `ghost`, as specified in the `compose.yml` 