### PR TITLE
Updated docker to RC.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # COMPOSE_PROFILES=analytics,activitypub
 
 # Which Ghost version to run
-GHOST_VERSION=6.0.0-rc.0-alpine
+GHOST_VERSION=6.0.0-rc.2-alpine
 
 # Public domain Ghost is going to run on
 DOMAIN=example.com

--- a/compose.yml
+++ b/compose.yml
@@ -22,7 +22,7 @@ services:
 
   ghost:
     # Do not alter this without updating the Tinybird Sync container as well
-    image: ghost:${GHOST_VERSION:-6.0.0-rc.0-alpine}
+    image: ghost:${GHOST_VERSION:-6.0.0-rc.2-alpine}
     restart: always
     expose:
       - "127.0.0.1:${GHOST_PORT:-2368}:2368"
@@ -143,7 +143,7 @@ services:
 
   tinybird-sync:
     # Do not alter this without updating the Ghost container as well
-    image: ghost:${GHOST_VERSION:-6.0.0-rc.0-alpine}
+    image: ghost:${GHOST_VERSION:-6.0.0-rc.2-alpine}
     command: >
       sh -c "
         if [ -d /var/lib/ghost/current/core/server/data/tinybird ]; then


### PR DESCRIPTION
ref: https://github.com/TryGhost/ghost-docker/pull/40

- Docker published RC2  on Friday I think
- Note 1: I just cut RC3, but that won't be available yet!
- Note 2: we prob need to rethink how we do versioning so we aren't pinning to exact versions