### PR TITLE
Added dependency on activitypub-migrate

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -120,6 +120,7 @@ services:
       LOCAL_STORAGE_HOSTING_URL: https://${DOMAIN}/content/images/activitypub
     depends_on:
       - db
+      - activitypub-migrate
     profiles: [activitypub]
     networks:
       - ghost_network


### PR DESCRIPTION
We need migrations to run before starting the activitypub service