### PR TITLE
Added x-frame-options for admin domains

### DIFF
--- a/caddy/snippets/SecurityHeaders
+++ b/caddy/snippets/SecurityHeaders
@@ -3,6 +3,7 @@ header {
 	Strict-Transport-Security max-age=31536000;
 	# Prevent embedding in frames
 	X-Frame-Options DENY
+    # X-Frame-Options allow from https://${ADMIN_DOMAIN}
 	# Enable XSS protection
 	X-XSS-Protection "1; mode=block"
 	# Prevent MIME sniffing


### PR DESCRIPTION
ref
https://linear.app/ghost/issue/ONC-1097/preview-post-does-not-work-on-separate-ghostadmin-domains

- Changed security headers x-frame-options for separate admin domains