### PR TITLE
Fixed "View site" and post previews in Ghost Admin

### DIFF
--- a/caddy/snippets/SecurityHeaders
+++ b/caddy/snippets/SecurityHeaders
@@ -1,12 +1,12 @@
 header {
 	# Enable HSTS
 	Strict-Transport-Security max-age=31536000;
-	# Prevent embedding in frames
-	X-Frame-Options DENY
 	# Enable XSS protection
 	X-XSS-Protection "1; mode=block"
 	# Prevent MIME sniffing
 	X-Content-Type-Options nosniff
 	# Referrer policy
 	Referrer-Policy strict-origin-when-cross-origin
+    # Prevent embedding in external iframes
+    Content-Security-Policy "frame-ancestors 'self' {$ADMIN_DOMAIN:}"
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1097/preview-post-does-not-work-on-separate-ghostadmin-domains ref https://linear.app/ghost/issue/ONC-1090/oss-issue-previewing-site-from-subdomain-admin-panel-results-in

In Ghost Admin, the frontend of the site is loaded in an iframe in a few places:
- The "View site" tab on the sidebar
- In post previews

Using the default docker setup in this repository, these iframes fail to load because of the `X-Frame-Options DENY` header that is added by Caddy. This fixes the problem by replacing `X-Frame-Options DENY` with a Content Security Policy that allows the site to be embedded in an iframe on the site's domain itself and on the admin domain, if configured.