### PR TITLE
Update Caddyfile.example to allow opening iframes on admin site

### DIFF
--- a/caddy/Caddyfile.example
+++ b/caddy/Caddyfile.example
@@ -12,6 +12,13 @@
 		reverse_proxy ghost:2368
 	}
 
+    # Uncomment below if using a separate domain for the admin page. It will allow only the admin origin to embed the site in the `view site` tab.
+    # header {
+    #   defer
+    #   -X-Frame-Options
+    #   Content-Security-Policy "frame-ancestors 'self' https://{$ADMIN_DOMAIN}"
+    # }
+
 	# Optional: Enable gzip compression
 	encode gzip
 


### PR DESCRIPTION
After installing with the default options, the `https://admin.domain/ghost/#/site` URL showed an error that the site could not be displayed in the iframe.

I am not great with Caddy, but looking at the documentation, this seemed reasonable.