### PR TITLE
Add mail.from config to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,9 +36,9 @@ mail__transport=SMTP
 mail__options__host=smtp.example.com
 mail__options__port=465
 mail__options__secure=true
-mail__options__auth__user=postmaster@example.com
+mail__options__auth__user=support@example.com
 mail__options__auth__pass=1234567890
-mail__from='Post Master <postmaster@example.com>'
+mail__from="'Acme Support' <support@example.com>"
 
 # Advanced customizations
 


### PR DESCRIPTION
It seems mail.from is needed for some mail server to work, otherwise transactional mails won't be sent successfully, with the following log: `Missing mail.from config, falling back to a generated email address. Please update your config file and set a valid from address`.

This pull request adds `mail.from` config to the mail config section in example `.env` file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add mail.from and update SMTP auth user in .env.example.
> 
> - **Config examples (`.env.example`)**:
>   - **SMTP**:
>     - Add `mail__from` example value.
>     - Update `mail__options__auth__user` to `support@example.com`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdc64988118e6e2cb32f48498fad3a196b678f16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->