### PR TITLE
fix(tinybird): use correct name for admin token

### DIFF
--- a/tinybird/getTokens.sh
+++ b/tinybird/getTokens.sh
@@ -32,7 +32,7 @@ RESPONSE=$(curl -s -X GET \
   -H "Authorization: Bearer $USER_TOKEN")
 
 # Parse tokens from response
-ADMIN_TOKEN=$(echo "$RESPONSE" | jq -r '.tokens[] | select(.name == "admin token") | .token')
+ADMIN_TOKEN=$(echo "$RESPONSE" | jq -r '.tokens[] | select(.name == "workspace admin token") | .token')
 TRACKER_TOKEN=$(echo "$RESPONSE" | jq -r '.tokens[] | select(.name == "tracker") | .token')
 
 # Echo the tokens as proof of concept


### PR DESCRIPTION
Fixes: #82 

Updates the `getTokens.sh` script to use the correct name "workspace admin token" when fetching the admin token from the Tinybird API.

The script was previously using "admin token" which does not correspond to any token returned by the API, causing it to fail when extracting the admin token from the API response. This change ensures the correct token is identified and output for the user.
