### PR TITLE
feat(compose): use existing nginx setup instead of caddy for SSL

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -5,8 +5,7 @@ services:
     image: caddy:2.10.0-alpine@sha256:e2e3a089760c453bc51c4e718342bd7032d6714f15b437db7121bfc2de2654a6
     restart: always
     ports:
-      - "80:80"
-      - "443:443"
+      - "127.0.0.1:8081:8081"
     environment:
       DOMAIN: ${DOMAIN:?DOMAIN environment variable is required}
       ADMIN_DOMAIN: ${ADMIN_DOMAIN:-}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update `caddy` service ports: remove `80/443` and bind `127.0.0.1:8081:8081`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aacd946493baeee77aea27ea790099956e6d80e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->