### PR TITLE
fix: fix typo in compose.yml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -126,7 +126,7 @@ services:
     networks:
       - ghost_network
 
-  # Suporting Services
+  # Supporting Services
 
   tinybird-login:
     build:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes a comment typo in `compose.yml` ('Suporting Services' → 'Supporting Services').
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7065970df5b4a58f66fcc4f8cf301621c47960e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->