### PR TITLE
Fix expose syntax in ghost container

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -24,8 +24,6 @@ services:
     # Do not alter this without updating the Tinybird Sync container as well
     image: ghost:${GHOST_VERSION:-6-alpine}
     restart: always
-    expose:
-      - "${GHOST_PORT:-2368}"
     # This is required to import current config when migrating
     env_file:
       - .env


### PR DESCRIPTION
There is currently a bug in the `compose.yml` that breaks `ghost-docker` on the latest Docker version.

`expose` does not support host binding syntax: https://docs.docker.com/reference/compose-file/services/#expose

The newest Docker version seems to validate this and breaks on `docker compose up`, essentially bricking sites:

```
Error response from daemon: invalid JSON: invalid port '127.0.0.1:2368:2368': invalid syntax
```
See also: https://forum.ghost.org/t/error-response-from-daemon-invalid-json-invalid-port-127-0-0-12368-invalid-syntax/60896

Steps to reproduce:
1. Update Docker to the latest version (`29.0.1`)
2. Run `docker compose up -d`
3. See error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove invalid host-bound expose from the `ghost` service in `compose.yml` to fix Docker Compose port syntax/validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 445de5301fee9e3c3c913ae52a1346386681197c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->