### PR TITLE
Enabled IPv6 networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Configuration to run Ghost and its services with Docker Compose
 
+## IPv6 networking
+
+IPv6 networking is opt-in because it requires newer Docker and Docker Compose versions than the base setup. Enable it by including the IPv6 override file:
+
+```sh
+docker compose -f compose.yml -f compose.ipv6.yml up -d
+```
+
 # Copyright & License 
 
 Copyright (c) 2013-2026 Ghost Foundation - Released under the [MIT license](LICENSE).

--- a/compose.ipv6.yml
+++ b/compose.ipv6.yml
@@ -1,0 +1,6 @@
+networks:
+  ghost_network:
+    enable_ipv6: true
+    ipam:
+      config:
+        - subnet: fdc1:f5e4:6668::/64

--- a/compose.yml
+++ b/compose.yml
@@ -205,3 +205,7 @@ volumes:
 
 networks:
   ghost_network:
+    enable_ipv6: true
+    ipam:
+      config:
+        - subnet: fdc1:f5e4:6668::/48

--- a/compose.yml
+++ b/compose.yml
@@ -205,7 +205,3 @@ volumes:
 
 networks:
   ghost_network:
-    enable_ipv6: true
-    ipam:
-      config:
-        - subnet: fdc1:f5e4:6668::/64

--- a/compose.yml
+++ b/compose.yml
@@ -208,4 +208,4 @@ networks:
     enable_ipv6: true
     ipam:
       config:
-        - subnet: fdc1:f5e4:6668::/48
+        - subnet: fdc1:f5e4:6668::/64


### PR DESCRIPTION
The `subnet` was randomly generated per RFC 4193.
