### PR TITLE
📝 Clarified GHOST_PORT comment in .env.example (#80)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,9 +53,11 @@ mail__from="'Acme Support' <support@example.com>"
 # The update commands won't work
 # GHOST_VERSION=6-alpine
 
-# Port Ghost should listen on
-# You should only need to edit this if you want to host
-# multiple sites on the same server
+# Internal port referenced by the migration script (scripts/migrate.sh)
+# when you opt out of Caddy and run your own webserver — it's printed in
+# the "forward traffic to 127.0.0.1:<port>" message. It does NOT change
+# the port Ghost listens on: Ghost binds 2368 internally and Caddy proxies
+# to it. To change the public port, set HTTP_PORT / HTTPS_PORT above.
 # GHOST_PORT=2368
 
 # Data locations


### PR DESCRIPTION
## What
Rewrites the GHOST_PORT comment in .env.example so it accurately describes
the variable's behaviour on current main.

## Why
Refs #80. After #88 removed the expose entry from the ghost service,
GHOST_PORT no longer affects the port Ghost serves on — it isn't referenced
in compose.yml and server__port is never set. Ghost listens on 2368
internally, caddy/Caddyfile.example proxies to ghost:2368, and the public
port is set via HTTP_PORT / HTTPS_PORT. The only remaining consumer of
GHOST_PORT is scripts/migrate.sh, which prints it in the "forward traffic to
127.0.0.1:<port>" migration message.

The existing comment ("Port Ghost should listen on… host multiple sites on
the same server") is inaccurate and has repeatedly confused users (#80). This
clarifies it and points to HTTP_PORT / HTTPS_PORT. It intentionally keeps the
`# GHOST_PORT=2368` line, since migrate.sh still reads it. Docs-only; it
doesn't address the separate "configurable internal port" discussion noted in
#88 — happy to adjust scope if you'd prefer it folded into that.

## How tested
Verified against current main by grepping the repo (GHOST_PORT, server__port,
2368) and reading compose.yml, caddy/Caddyfile.example, and scripts/migrate.sh.
Docs-only change; no behaviour modified.