### PR TITLE
fix(compose): keep the MySQL root password out of the healthcheck process list

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -73,7 +73,7 @@ services:
       - ${MYSQL_DATA_LOCATION:-./data/mysql}:/var/lib/mysql
       - ./mysql-init:/docker-entrypoint-initdb.d
     healthcheck:
-      test: mysqladmin ping -p$$MYSQL_ROOT_PASSWORD -h 127.0.0.1
+      test: MYSQL_PWD="$$MYSQL_ROOT_PASSWORD" mysqladmin ping -h 127.0.0.1
       interval: 1s
       start_period: 30s
       start_interval: 10s


### PR DESCRIPTION
The db healthcheck passes the root password with -p on the command line:

test: mysqladmin ping -p$$MYSQL_ROOT_PASSWORD -h 127.0.0.1
Anything that can list processes in that container's PID namespace - docker top ghost-db, ps from inside the container, or a compromised sidecar sharing the namespace - can read MYSQL_ROOT_PASSWORD in plaintext from the mysqladmin argv.

This passes the password via the MYSQL_PWD env var instead, which mysqladmin reads automatically and which never appears in the process list:

test: MYSQL_PWD="$$MYSQL_ROOT_PASSWORD" mysqladmin ping -h 127.0.0.1
Behaviour is identical (same user, same ping); only the password stops leaking into argv. MySQL's own docs advise against -p<password> on the CLI for exactly this reason. docker compose config still validates.